### PR TITLE
Make RandomPersonTransformer GetFullName concurrency safe

### DIFF
--- a/pkg/generators/transformers/random_person.go
+++ b/pkg/generators/transformers/random_person.go
@@ -187,8 +187,7 @@ type RandomPersonTransformer struct {
 	// db - mapping gender to other personal attribute
 	// common structure
 	// gender -> person_attribute -> []possible values
-	db     *PersonDatabase
-	result map[string]string
+	db *PersonDatabase
 }
 
 func NewRandomPersonTransformer(gender string, personDb Database) *RandomPersonTransformer {
@@ -203,7 +202,6 @@ func NewRandomPersonTransformer(gender string, personDb Database) *RandomPersonT
 		gender: gender,
 		// we assume 4 bytes peer attribute + 1 byte for gender
 		db:         db,
-		result:     make(map[string]string, db.AttributesCount),
 		byteLength: db.AttributesCount * 4,
 	}
 }
@@ -213,7 +211,7 @@ func (rpt *RandomPersonTransformer) GetDb() *PersonDatabase {
 }
 
 func (rpt *RandomPersonTransformer) GetFullName(gender string, original []byte) (map[string]string, error) {
-
+	result := make(map[string]string, rpt.db.AttributesCount)
 	resBytes, err := rpt.generator.Generate(original)
 	if err != nil {
 		return nil, err
@@ -228,11 +226,11 @@ func (rpt *RandomPersonTransformer) GetFullName(gender string, original []byte) 
 	startIdx := 1
 	for _, attr := range rpt.db.Attributes {
 		attrIdx := binary.LittleEndian.Uint32(resBytes[startIdx : startIdx+4])
-		rpt.result[attr] = rpt.db.GetRandomAttribute(gender, attr, attrIdx)
+		result[attr] = rpt.db.GetRandomAttribute(gender, attr, attrIdx)
 		startIdx += 4
 	}
 
-	return rpt.result, nil
+	return result, nil
 }
 
 func (rpt *RandomPersonTransformer) getGender(gender string, randomGenderIdx byte) (string, error) {


### PR DESCRIPTION
Currently the `RandomPersonTransformer` uses a shared result map that is populated in the `GetFullName` method, which prevents it from being used concurrently. This PR updates it so that each `GetFullName` call produces its own result, making it concurrency safe. This allows to reuse the same transformer for multiple concurrent transformations.

Fixes https://github.com/xataio/pgstream/issues/445.