### PR TITLE
Protect access to `rand.Seed` using a mutex

### DIFF
--- a/pkg/generators/hybrid.go
+++ b/pkg/generators/hybrid.go
@@ -3,9 +3,11 @@ package generators
 import (
 	"encoding/binary"
 	"math/rand"
+	"sync"
 )
 
 type HybridBytes struct {
+	mu          sync.Mutex
 	r           *rand.Rand
 	g           Generator
 	size        int
@@ -40,6 +42,8 @@ func NewHybridBytes(seed int64, requestedSize int, h Generator) *HybridBytes {
 }
 
 func (hb *HybridBytes) Generate(data []byte) ([]byte, error) {
+	hb.mu.Lock()
+	defer hb.mu.Unlock()
 	hb.resBuf = hb.resBuf[:0]
 	res, err := hb.g.Generate(data)
 	if err != nil {

--- a/pkg/generators/random_bytes.go
+++ b/pkg/generators/random_bytes.go
@@ -3,9 +3,11 @@ package generators
 import (
 	"encoding/binary"
 	"math/rand"
+	"sync"
 )
 
 type RandomBytes struct {
+	mu    sync.Mutex
 	r     *rand.Rand
 	size  int
 	iters int
@@ -26,6 +28,8 @@ func NewRandomBytes(seed int64, size int) *RandomBytes {
 func (br *RandomBytes) Generate(data []byte) ([]byte, error) {
 	res := make([]byte, 0, br.size)
 	buf := make([]byte, 8)
+	br.mu.Lock()
+	defer br.mu.Unlock()
 	for i := 0; i < br.iters; i++ {
 		binary.LittleEndian.PutUint64(buf, br.r.Uint64())
 		res = append(res, buf...)

--- a/pkg/generators/random_int64.go
+++ b/pkg/generators/random_int64.go
@@ -3,9 +3,11 @@ package generators
 import (
 	"encoding/binary"
 	"math/rand"
+	"sync"
 )
 
 type Int64Random struct {
+	mu   sync.Mutex
 	r    *rand.Rand
 	size int
 }
@@ -19,6 +21,8 @@ func NewInt64Random(seed int64) (*Int64Random, error) {
 
 func (i *Int64Random) Generate(data []byte) ([]byte, error) {
 	res := make([]byte, i.size)
+	i.mu.Lock()
+	defer i.mu.Unlock()
 	binary.LittleEndian.PutUint64(res, i.r.Uint64())
 	return res, nil
 }

--- a/pkg/generators/random_int64_test.go
+++ b/pkg/generators/random_int64_test.go
@@ -1,6 +1,7 @@
 package generators
 
 import (
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -12,4 +13,41 @@ func TestBytesRandom_Generate(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, res, 3)
 	require.Equal(t, []byte{1, 148, 253}, res)
+}
+
+func TestRandomBytes_GenerateConcurrent(t *testing.T) {
+	r := NewRandomBytes(0, 16)
+	var wg sync.WaitGroup
+	for i := 0; i < 64; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 1000; j++ {
+				if _, err := r.Generate(nil); err != nil {
+					t.Errorf("Generate returned error: %v", err)
+					return
+				}
+			}
+		}()
+	}
+	wg.Wait()
+}
+
+func TestInt64Random_GenerateConcurrent(t *testing.T) {
+	r, err := NewInt64Random(0)
+	require.NoError(t, err)
+	var wg sync.WaitGroup
+	for i := 0; i < 64; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 1000; j++ {
+				if _, err := r.Generate(nil); err != nil {
+					t.Errorf("Generate returned error: %v", err)
+					return
+				}
+			}
+		}()
+	}
+	wg.Wait()
 }


### PR DESCRIPTION
This PR adds a mutex to protect access to `rand.Seed` so generators can be used concurrently.
